### PR TITLE
feat: WorkOS AuthKit login + sealed BFF session (FNS-91)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to `.env` and fill in. Bun loads `.env` into the environment for `bun run dev`.
+# `.env` is gitignored — never commit real credentials.
+
+# From the WorkOS dashboard: API Keys.
+WORKOS_API_KEY=sk_test_...
+
+# From the WorkOS dashboard: Applications → your app.
+WORKOS_CLIENT_ID=client_...
+
+# Encrypts the session cookie. Must be at least 32 characters.
+# Generate one with: openssl rand -base64 32
+WORKOS_COOKIE_PASSWORD=
+
+# Must be registered verbatim as a redirect URI in the WorkOS dashboard.
+WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback

--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ TypeScript (strict) · React 19
 
 ```sh
 bun install
-bun run dev        # http://localhost:3000  (SSR + HMR)
+cp .env.example .env   # then fill in the WorkOS values
+bun run dev            # http://localhost:3000  (SSR + HMR)
 ```
 
 Routes live in `src/routes/`, shared UI in `src/components/`.
+
+The auth routes need the `WORKOS_*` variables in [`.env.example`](./.env.example); the rest
+of the app runs without them, since the config is read per-request rather than at boot.
 
 | Script | What |
 | --- | --- |
@@ -35,6 +39,17 @@ code style lives in [`docs/coding-standards/react-typescript.md`](./docs/coding-
 - `/` — walking-skeleton landing page.
 - `/healthz` — liveness for the ALB target group (200 = server up + SSR renders).
 
+Auth (server-only handlers; no client bundle, no component):
+
+- `GET /auth/login` — issues an OAuth `state` cookie, redirects to WorkOS AuthKit (Google).
+- `GET /auth/callback` — verifies `state`, exchanges the code, seals the session cookie.
+- `POST /auth/logout` — clears the session cookie, redirects to the WorkOS logout URL.
+  POST, not GET: a GET logout is CSRF-able and gets triggered by link prefetchers.
+
+The browser only ever holds an opaque, sealed, `httpOnly` cookie. It is unsealed solely
+on the server, which is where the WorkOS access token is read before being forwarded to
+the Go services.
+
 ## Docker
 
 ```sh
@@ -49,6 +64,9 @@ that needs a hosting adapter to inject the client manifest and serve `dist/clien
 
 ## Roadmap (this scaffold = FNS-138)
 
-- **FNS-91** — WorkOS AuthKit login + session in the BFF.
+- **FNS-91** — WorkOS AuthKit login + session in the BFF. Login, callback, logout and the
+  sealed session cookie are done; JIT-provisioning the canonical user via
+  `IdentityService.ResolveUser` is still to come, and waits on the `apis` TS package
+  being published to GitHub Packages.
 - **FNS-94** — profile view/edit/preferences, consuming `authx.ProfileService` (FNS-93, done).
 - **FNS-111** — production multi-stage Docker build + SSR asset serving.

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@tanstack/react-router": "^1.170.17",
         "@tanstack/react-start": "^1.168.27",
+        "@workos-inc/node": "^10.7.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
       },
@@ -305,6 +306,8 @@
     "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
+    "@workos-inc/node": ["@workos-inc/node@10.7.0", "", {}, "sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+
+// The auth routes are server-only handlers, so `request` (which runs no JavaScript)
+// is exactly the right fixture: anything it observes came from the BFF.
+
+test('GET /auth/login redirects to WorkOS and issues a state cookie', async ({ request }) => {
+  const res = await request.get('/auth/login', { maxRedirects: 0 })
+
+  expect(res.status()).toBe(302)
+
+  const location = res.headers()['location'] ?? ''
+  expect(location).not.toBe('')
+
+  const authorizeUrl = new URL(location)
+  expect(authorizeUrl.host).toBe('api.workos.com')
+  expect(authorizeUrl.searchParams.get('provider')).toBe('GoogleOAuth')
+  expect(authorizeUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/auth/callback')
+
+  const state = authorizeUrl.searchParams.get('state') ?? ''
+  expect(state).not.toBe('')
+
+  // The same state must come back as an httpOnly cookie so the callback can match it.
+  const setCookie = res.headers()['set-cookie'] ?? ''
+  expect(setCookie).toContain('fns_oauth_state=')
+  expect(setCookie).toContain('HttpOnly')
+  expect(setCookie).toContain(encodeURIComponent(state))
+})
+
+test('GET /auth/callback rejects a request with no authorization code', async ({ request }) => {
+  const res = await request.get('/auth/callback', { maxRedirects: 0 })
+
+  expect(res.status()).toBe(400)
+  expect(await res.text()).toContain('Missing authorization code')
+})
+
+test('GET /auth/callback rejects a code with no matching state cookie', async ({ request }) => {
+  // This is the CSRF case: an attacker hands the victim a callback URL bearing
+  // the attacker's own code. With no state cookie from a login we started, it fails.
+  const res = await request.get('/auth/callback?code=attacker_code&state=forged', {
+    maxRedirects: 0,
+  })
+
+  expect(res.status()).toBe(400)
+  expect(await res.text()).toContain('Invalid OAuth state')
+})
+
+test('GET /auth/callback rejects a state that does not match the issued cookie', async ({
+  request,
+}) => {
+  // Start a real login so the browser holds a genuine state cookie...
+  await request.get('/auth/login', { maxRedirects: 0 })
+
+  // ...then come back with a different state than the one that was issued.
+  const res = await request.get('/auth/callback?code=some_code&state=not-the-issued-state', {
+    maxRedirects: 0,
+  })
+
+  expect(res.status()).toBe(400)
+  expect(await res.text()).toContain('Invalid OAuth state')
+})
+
+test('POST /auth/logout clears the session and redirects home', async ({ request }) => {
+  const res = await request.post('/auth/logout', { maxRedirects: 0 })
+
+  expect(res.status()).toBe(302)
+  expect(res.headers()['location']).toBe('/')
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,14 @@ export default tseslint.config(
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
       ],
+      // `throw redirect({ to: '…' })` is how TanStack Router unwinds a loader or
+      // server function into a redirect. Everything else must still be an Error.
+      '@typescript-eslint/only-throw-error': [
+        'error',
+        {
+          allow: [{ from: 'package', package: '@tanstack/router-core', name: 'Redirect' }],
+        },
+      ],
     },
   },
 )

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@tanstack/react-router": "^1.170.17",
     "@tanstack/react-start": "^1.168.27",
+    "@workos-inc/node": "^10.7.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,5 +11,14 @@ export default defineConfig({
     command: 'bun run dev',
     port: 3000,
     reuseExistingServer: !process.env['CI'],
+    // Placeholders, not credentials. The auth specs only exercise paths that stay
+    // inside the BFF: building the authorize URL is pure string work, and the
+    // callback specs are rejected on `state` before any WorkOS call is made.
+    env: {
+      WORKOS_API_KEY: 'sk_test_placeholder',
+      WORKOS_CLIENT_ID: 'client_placeholder',
+      WORKOS_COOKIE_PASSWORD: 'placeholder-cookie-password-32-chars',
+      WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+    },
   },
 })

--- a/src/lib/auth/config.server.test.ts
+++ b/src/lib/auth/config.server.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getWorkOSConfig } from './config.server'
+
+const VALID_ENV = {
+  WORKOS_API_KEY: 'sk_test_key',
+  WORKOS_CLIENT_ID: 'client_123',
+  WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
+  WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+} as const
+
+let originalEnv: NodeJS.ProcessEnv
+
+beforeEach(() => {
+  originalEnv = { ...process.env }
+  Object.assign(process.env, VALID_ENV)
+})
+
+afterEach(() => {
+  process.env = originalEnv
+})
+
+describe('getWorkOSConfig', () => {
+  it('reads every WorkOS setting from the environment', () => {
+    expect(getWorkOSConfig()).toEqual({
+      apiKey: 'sk_test_key',
+      clientId: 'client_123',
+      cookiePassword: 'a'.repeat(32),
+      redirectUri: 'http://localhost:3000/auth/callback',
+    })
+  })
+
+  it.each(Object.keys(VALID_ENV))('throws when %s is missing', (name) => {
+    delete process.env[name]
+    expect(() => getWorkOSConfig()).toThrow(`Missing required environment variable: ${name}`)
+  })
+
+  it.each(Object.keys(VALID_ENV))('throws when %s is empty', (name) => {
+    process.env[name] = ''
+    expect(() => getWorkOSConfig()).toThrow(`Missing required environment variable: ${name}`)
+  })
+
+  it('rejects a cookie password too short for the seal key', () => {
+    process.env['WORKOS_COOKIE_PASSWORD'] = 'a'.repeat(31)
+    expect(() => getWorkOSConfig()).toThrow(/at least 32 characters, got 31/)
+  })
+
+  it('accepts a cookie password of exactly the minimum length', () => {
+    process.env['WORKOS_COOKIE_PASSWORD'] = 'a'.repeat(32)
+    expect(getWorkOSConfig().cookiePassword).toHaveLength(32)
+  })
+})

--- a/src/lib/auth/config.server.ts
+++ b/src/lib/auth/config.server.ts
@@ -1,0 +1,42 @@
+/**
+ * WorkOS configuration, read from the environment.
+ *
+ * Read lazily rather than at module scope: a missing variable should fail the
+ * request that needs it, not the build or a `vite dev` boot that never touches auth.
+ */
+
+/** Iron derives the seal key from this password and rejects anything shorter. */
+const MIN_COOKIE_PASSWORD_LENGTH = 32
+
+export type WorkOSConfig = Readonly<{
+  apiKey: string
+  clientId: string
+  cookiePassword: string
+  redirectUri: string
+}>
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+export function getWorkOSConfig(): WorkOSConfig {
+  const cookiePassword = requireEnv('WORKOS_COOKIE_PASSWORD')
+  // Checked here so a too-short password surfaces as a clear error rather than
+  // as an opaque failure deep inside the seal step on the OAuth callback.
+  if (cookiePassword.length < MIN_COOKIE_PASSWORD_LENGTH) {
+    throw new Error(
+      `WORKOS_COOKIE_PASSWORD must be at least ${MIN_COOKIE_PASSWORD_LENGTH} characters, got ${cookiePassword.length}`,
+    )
+  }
+
+  return {
+    apiKey: requireEnv('WORKOS_API_KEY'),
+    clientId: requireEnv('WORKOS_CLIENT_ID'),
+    cookiePassword,
+    redirectUri: requireEnv('WORKOS_REDIRECT_URI'),
+  }
+}

--- a/src/lib/auth/oauth-state.test.ts
+++ b/src/lib/auth/oauth-state.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { createOAuthState, isSameOAuthState } from './oauth-state'
+
+describe('createOAuthState', () => {
+  it('generates a URL-safe value', () => {
+    expect(createOAuthState()).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('generates a different value on each call', () => {
+    const states = new Set(Array.from({ length: 50 }, () => createOAuthState()))
+    expect(states.size).toBe(50)
+  })
+})
+
+describe('isSameOAuthState', () => {
+  it('accepts a value that matches the one issued at login', () => {
+    const state = createOAuthState()
+    expect(isSameOAuthState(state, state)).toBe(true)
+  })
+
+  it('rejects a value that does not match', () => {
+    expect(isSameOAuthState(createOAuthState(), createOAuthState())).toBe(false)
+  })
+
+  it('rejects a value of a different length instead of throwing', () => {
+    // timingSafeEqual throws on mismatched lengths; the guard must catch it first.
+    expect(() => isSameOAuthState('short', 'considerably-longer')).not.toThrow()
+    expect(isSameOAuthState('short', 'considerably-longer')).toBe(false)
+  })
+
+  it('rejects a prefix of the expected value', () => {
+    const state = createOAuthState()
+    expect(isSameOAuthState(state.slice(0, -1), state)).toBe(false)
+  })
+
+  it('rejects an empty received value', () => {
+    expect(isSameOAuthState('', createOAuthState())).toBe(false)
+  })
+})

--- a/src/lib/auth/oauth-state.ts
+++ b/src/lib/auth/oauth-state.ts
@@ -1,0 +1,25 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+
+/**
+ * The OAuth `state` parameter, which ties a callback back to the login request
+ * that started it. Without it, an attacker can hand a victim's browser a callback
+ * URL bearing their own `code` and log the victim into the attacker's account.
+ */
+
+const STATE_BYTES = 32
+
+export function createOAuthState(): string {
+  return randomBytes(STATE_BYTES).toString('base64url')
+}
+
+/** Compare in constant time so the check can't be turned into a byte-at-a-time oracle. */
+export function isSameOAuthState(received: string, expected: string): boolean {
+  const receivedBytes = Buffer.from(received, 'utf8')
+  const expectedBytes = Buffer.from(expected, 'utf8')
+
+  // timingSafeEqual throws on a length mismatch, which would itself leak length.
+  if (receivedBytes.length !== expectedBytes.length) {
+    return false
+  }
+  return timingSafeEqual(receivedBytes, expectedBytes)
+}

--- a/src/lib/auth/session.server.test.ts
+++ b/src/lib/auth/session.server.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Both mocks sit on external boundaries: the Start server runtime holds its cookie
+// helpers in request-scoped AsyncLocalStorage that has no equivalent under Vitest,
+// and WorkOS is a third-party service. Nothing we own is mocked.
+const mocks = vi.hoisted(() => ({
+  getCookie: vi.fn<(name: string) => string | undefined>(),
+  setCookie: vi.fn(),
+  deleteCookie: vi.fn(),
+  loadSealedSession: vi.fn(),
+  workosConstructor: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getCookie: mocks.getCookie,
+  setCookie: mocks.setCookie,
+  deleteCookie: mocks.deleteCookie,
+}))
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class {
+    userManagement = { loadSealedSession: mocks.loadSealedSession }
+    constructor(apiKey: string, options: { clientId: string }) {
+      mocks.workosConstructor(apiKey, options)
+    }
+  },
+}))
+
+const { SESSION_COOKIE_NAME, getSession, getWorkOS } = await import('./session.server')
+
+const VALID_ENV = {
+  WORKOS_API_KEY: 'sk_test_key',
+  WORKOS_CLIENT_ID: 'client_123',
+  WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
+  WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+} as const
+
+const USER = { id: 'user_1', email: 'ada@example.com' }
+
+let originalEnv: NodeJS.ProcessEnv
+
+beforeEach(() => {
+  originalEnv = { ...process.env }
+  Object.assign(process.env, VALID_ENV)
+})
+
+afterEach(() => {
+  process.env = originalEnv
+  vi.clearAllMocks()
+})
+
+// The client is cached in module scope, which outlives any single test. Each test
+// therefore primes the cache first and only then asserts on what follows.
+describe('getWorkOS', () => {
+  it('reuses one client across calls so the cached JWKS survives', () => {
+    getWorkOS()
+    mocks.workosConstructor.mockClear()
+
+    getWorkOS()
+    getWorkOS()
+
+    expect(mocks.workosConstructor).not.toHaveBeenCalled()
+  })
+
+  it('builds a new client once the credentials are rotated', () => {
+    getWorkOS()
+    mocks.workosConstructor.mockClear()
+
+    process.env['WORKOS_API_KEY'] = 'sk_test_rotated'
+    getWorkOS()
+
+    expect(mocks.workosConstructor).toHaveBeenCalledTimes(1)
+    expect(mocks.workosConstructor).toHaveBeenLastCalledWith('sk_test_rotated', {
+      clientId: 'client_123',
+    })
+  })
+})
+
+describe('getSession', () => {
+  it('returns null for a visitor with no session cookie', async () => {
+    mocks.getCookie.mockReturnValue(undefined)
+
+    expect(await getSession()).toBeNull()
+    expect(mocks.loadSealedSession).not.toHaveBeenCalled()
+  })
+
+  it('returns the access token and user for a valid session', async () => {
+    mocks.getCookie.mockReturnValue('sealed-cookie')
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({
+        authenticated: true,
+        accessToken: 'access-token',
+        user: USER,
+      }),
+      refresh: vi.fn(),
+    })
+
+    expect(await getSession()).toEqual({ accessToken: 'access-token', user: USER })
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+  })
+
+  it('signs the visitor out instead of throwing when the cookie cannot be unsealed', async () => {
+    // Regression: a tampered cookie, or one sealed with a since-rotated password,
+    // makes `authenticate()` throw rather than return a structured failure. That
+    // used to escape as a 500 on every request the visitor made.
+    mocks.getCookie.mockReturnValue('tampered-cookie')
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockRejectedValue(new Error('Cannot decrypt sealed data')),
+      refresh: vi.fn(),
+    })
+
+    expect(await getSession()).toBeNull()
+    expect(mocks.deleteCookie).toHaveBeenCalledWith(SESSION_COOKIE_NAME, expect.anything())
+  })
+
+  it('signs the visitor out instead of throwing when refreshing throws', async () => {
+    mocks.getCookie.mockReturnValue('sealed-cookie')
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({ authenticated: false, reason: 'invalid_jwt' }),
+      refresh: vi.fn().mockRejectedValue(new Error('Cannot decrypt sealed data')),
+    })
+
+    expect(await getSession()).toBeNull()
+    expect(mocks.deleteCookie).toHaveBeenCalledWith(SESSION_COOKIE_NAME, expect.anything())
+  })
+
+  it('renews an expired access token and re-seals the cookie', async () => {
+    mocks.getCookie.mockReturnValue('stale-cookie')
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({ authenticated: false, reason: 'invalid_jwt' }),
+      refresh: vi.fn().mockResolvedValue({
+        authenticated: true,
+        sealedSession: 'resealed-cookie',
+        session: { accessToken: 'fresh-token' },
+        user: USER,
+      }),
+    })
+
+    expect(await getSession()).toEqual({ accessToken: 'fresh-token', user: USER })
+    expect(mocks.setCookie).toHaveBeenCalledWith(
+      SESSION_COOKIE_NAME,
+      'resealed-cookie',
+      expect.anything(),
+    )
+  })
+
+  it('signs the visitor out when the refresh token is spent', async () => {
+    mocks.getCookie.mockReturnValue('stale-cookie')
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({ authenticated: false, reason: 'invalid_jwt' }),
+      refresh: vi.fn().mockResolvedValue({ authenticated: false, reason: 'invalid_grant' }),
+    })
+
+    expect(await getSession()).toBeNull()
+    expect(mocks.deleteCookie).toHaveBeenCalledWith(SESSION_COOKIE_NAME, expect.anything())
+  })
+})

--- a/src/lib/auth/session.server.ts
+++ b/src/lib/auth/session.server.ts
@@ -24,14 +24,21 @@ export type Session = Readonly<{
   user: User
 }>
 
-let client: WorkOS | undefined
+let cached: { credentials: string; client: WorkOS } | undefined
 
+/**
+ * The client is reused rather than rebuilt per request because each instance
+ * caches the WorkOS JWKS used to verify access tokens. It is keyed on the
+ * credentials so that rotating them takes effect on the next request.
+ */
 export function getWorkOS(): WorkOS {
-  if (!client) {
-    const { apiKey, clientId } = getWorkOSConfig()
-    client = new WorkOS(apiKey, { clientId })
+  const { apiKey, clientId } = getWorkOSConfig()
+  const credentials = `${apiKey}:${clientId}`
+
+  if (cached?.credentials !== credentials) {
+    cached = { credentials, client: new WorkOS(apiKey, { clientId }) }
   }
-  return client
+  return cached.client
 }
 
 // `secure` would make the cookie undeliverable over plain-HTTP localhost, where
@@ -89,19 +96,28 @@ export async function getSession(): Promise<Session | null> {
     cookiePassword,
   })
 
-  const authenticated = await sealed.authenticate()
-  if (authenticated.authenticated) {
-    return { accessToken: authenticated.accessToken, user: authenticated.user }
-  }
+  try {
+    const authenticated = await sealed.authenticate()
+    if (authenticated.authenticated) {
+      return { accessToken: authenticated.accessToken, user: authenticated.user }
+    }
 
-  const refreshed = await sealed.refresh({ cookiePassword })
-  if (!refreshed.authenticated || !refreshed.sealedSession || !refreshed.session) {
+    const refreshed = await sealed.refresh({ cookiePassword })
+    if (!refreshed.authenticated || !refreshed.sealedSession || !refreshed.session) {
+      clearSessionCookie()
+      return null
+    }
+
+    setSessionCookie(refreshed.sealedSession)
+    return { accessToken: refreshed.session.accessToken, user: refreshed.user }
+  } catch {
+    // Unsealing throws outright on a tampered cookie, or on one sealed with a
+    // since-rotated password — unlike every other failure here, which comes back
+    // as a structured result. A visitor holding an unreadable cookie is simply
+    // not signed in; discard it rather than serving them a 500 forever.
     clearSessionCookie()
     return null
   }
-
-  setSessionCookie(refreshed.sealedSession)
-  return { accessToken: refreshed.session.accessToken, user: refreshed.user }
 }
 
 /** Same as {@link getSession}, but redirects anonymous callers to the login route. */

--- a/src/lib/auth/session.server.ts
+++ b/src/lib/auth/session.server.ts
@@ -1,0 +1,114 @@
+import { WorkOS } from '@workos-inc/node'
+import type { User } from '@workos-inc/node'
+import { redirect } from '@tanstack/react-router'
+import { deleteCookie, getCookie, setCookie } from '@tanstack/react-start/server'
+import { getWorkOSConfig } from './config.server'
+
+/**
+ * The BFF's half of the WorkOS session (ADR-4/ADR-5).
+ *
+ * The browser only ever holds an opaque, sealed, httpOnly cookie. Unsealing it —
+ * and therefore the WorkOS access token forwarded to the Go services — happens
+ * exclusively here on the server.
+ */
+
+export const SESSION_COOKIE_NAME = 'fns_session'
+export const OAUTH_STATE_COOKIE_NAME = 'fns_oauth_state'
+
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+const OAUTH_STATE_MAX_AGE_SECONDS = 60 * 10
+
+/** A verified session. `accessToken` is what gets forwarded to the Go services. */
+export type Session = Readonly<{
+  accessToken: string
+  user: User
+}>
+
+let client: WorkOS | undefined
+
+export function getWorkOS(): WorkOS {
+  if (!client) {
+    const { apiKey, clientId } = getWorkOSConfig()
+    client = new WorkOS(apiKey, { clientId })
+  }
+  return client
+}
+
+// `secure` would make the cookie undeliverable over plain-HTTP localhost, where
+// the OAuth callback lands during development.
+const isProduction = (): boolean => process.env['NODE_ENV'] === 'production'
+
+const baseCookieOptions = () =>
+  ({
+    httpOnly: true,
+    secure: isProduction(),
+    sameSite: 'lax',
+    path: '/',
+  }) as const
+
+export function setSessionCookie(sealedSession: string): void {
+  setCookie(SESSION_COOKIE_NAME, sealedSession, {
+    ...baseCookieOptions(),
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  })
+}
+
+export function clearSessionCookie(): void {
+  deleteCookie(SESSION_COOKIE_NAME, baseCookieOptions())
+}
+
+export function setOAuthStateCookie(state: string): void {
+  setCookie(OAUTH_STATE_COOKIE_NAME, state, {
+    ...baseCookieOptions(),
+    maxAge: OAUTH_STATE_MAX_AGE_SECONDS,
+  })
+}
+
+export function takeOAuthStateCookie(): string | undefined {
+  const state = getCookie(OAUTH_STATE_COOKIE_NAME)
+  deleteCookie(OAUTH_STATE_COOKIE_NAME, baseCookieOptions())
+  return state
+}
+
+/**
+ * Resolve the current session, or `null` if the caller is not signed in.
+ *
+ * WorkOS access tokens expire after a few minutes, so an unauthenticated result
+ * is retried once through the refresh token before giving up. A successful
+ * refresh re-seals the cookie, which is why this can mutate the response.
+ */
+export async function getSession(): Promise<Session | null> {
+  const sessionData = getCookie(SESSION_COOKIE_NAME)
+  if (!sessionData) {
+    return null
+  }
+
+  const { cookiePassword } = getWorkOSConfig()
+  const sealed = getWorkOS().userManagement.loadSealedSession({
+    sessionData,
+    cookiePassword,
+  })
+
+  const authenticated = await sealed.authenticate()
+  if (authenticated.authenticated) {
+    return { accessToken: authenticated.accessToken, user: authenticated.user }
+  }
+
+  const refreshed = await sealed.refresh({ cookiePassword })
+  if (!refreshed.authenticated || !refreshed.sealedSession || !refreshed.session) {
+    clearSessionCookie()
+    return null
+  }
+
+  setSessionCookie(refreshed.sealedSession)
+  return { accessToken: refreshed.session.accessToken, user: refreshed.user }
+}
+
+/** Same as {@link getSession}, but redirects anonymous callers to the login route. */
+export async function requireSession(): Promise<Session> {
+  const session = await getSession()
+  if (!session) {
+    throw redirect({ to: '/auth/login' })
+  }
+  return session
+}

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,4 @@
+/** A bare 302. Cookies queued with `setCookie`/`deleteCookie` are attached to this by the server runtime. */
+export function redirectResponse(location: string): Response {
+  return new Response(null, { status: 302, headers: { location } })
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,9 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as HealthzRouteImport } from './routes/healthz'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthLogoutRouteImport } from './routes/auth.logout'
+import { Route as AuthLoginRouteImport } from './routes/auth.login'
+import { Route as AuthCallbackRouteImport } from './routes/auth.callback'
 
 const HealthzRoute = HealthzRouteImport.update({
   id: '/healthz',
@@ -22,31 +25,65 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthLogoutRoute = AuthLogoutRouteImport.update({
+  id: '/auth/logout',
+  path: '/auth/logout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthLoginRoute = AuthLoginRouteImport.update({
+  id: '/auth/login',
+  path: '/auth/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthCallbackRoute = AuthCallbackRouteImport.update({
+  id: '/auth/callback',
+  path: '/auth/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/healthz': typeof HealthzRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
+  '/auth/logout': typeof AuthLogoutRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/healthz': typeof HealthzRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
+  '/auth/logout': typeof AuthLogoutRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/healthz': typeof HealthzRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/login': typeof AuthLoginRoute
+  '/auth/logout': typeof AuthLogoutRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/healthz'
+  fullPaths:
+    '/' | '/healthz' | '/auth/callback' | '/auth/login' | '/auth/logout'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/healthz'
-  id: '__root__' | '/' | '/healthz'
+  to: '/' | '/healthz' | '/auth/callback' | '/auth/login' | '/auth/logout'
+  id:
+    | '__root__'
+    | '/'
+    | '/healthz'
+    | '/auth/callback'
+    | '/auth/login'
+    | '/auth/logout'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   HealthzRoute: typeof HealthzRoute
+  AuthCallbackRoute: typeof AuthCallbackRoute
+  AuthLoginRoute: typeof AuthLoginRoute
+  AuthLogoutRoute: typeof AuthLogoutRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -65,12 +102,36 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/auth/logout': {
+      id: '/auth/logout'
+      path: '/auth/logout'
+      fullPath: '/auth/logout'
+      preLoaderRoute: typeof AuthLogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/login': {
+      id: '/auth/login'
+      path: '/auth/login'
+      fullPath: '/auth/login'
+      preLoaderRoute: typeof AuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/callback': {
+      id: '/auth/callback'
+      path: '/auth/callback'
+      fullPath: '/auth/callback'
+      preLoaderRoute: typeof AuthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   HealthzRoute: HealthzRoute,
+  AuthCallbackRoute: AuthCallbackRoute,
+  AuthLoginRoute: AuthLoginRoute,
+  AuthLogoutRoute: AuthLogoutRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/auth.callback.test.ts
+++ b/src/routes/auth.callback.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OauthException } from '@workos-inc/node'
+import type * as WorkOSModule from '@workos-inc/node'
+
+// External boundaries only: the Start server runtime (request-scoped cookie and
+// request helpers, which have no Vitest equivalent) and the WorkOS service.
+const mocks = vi.hoisted(() => ({
+  getRequest: vi.fn<() => Request>(),
+  getCookie: vi.fn<(name: string) => string | undefined>(),
+  setCookie: vi.fn(),
+  deleteCookie: vi.fn(),
+  authenticateWithCode: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getRequest: mocks.getRequest,
+  getCookie: mocks.getCookie,
+  setCookie: mocks.setCookie,
+  deleteCookie: mocks.deleteCookie,
+}))
+
+vi.mock('@workos-inc/node', async (importOriginal) => {
+  // Keep the real OauthException: the route narrows on it with `instanceof`.
+  const actual = await importOriginal<typeof WorkOSModule>()
+  return {
+    ...actual,
+    WorkOS: class {
+      userManagement = { authenticateWithCode: mocks.authenticateWithCode }
+    },
+  }
+})
+
+const { Route } = await import('./auth.callback')
+
+const VALID_ENV = {
+  WORKOS_API_KEY: 'sk_test_key',
+  WORKOS_CLIENT_ID: 'client_123',
+  WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
+  WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+} as const
+
+const STATE = 'the-issued-state'
+
+/** Pull the bare GET handler off the route definition. */
+function getHandler(): () => Promise<Response> {
+  const handlers = Route.options.server?.handlers
+  if (!handlers || typeof handlers === 'function' || !handlers.GET) {
+    throw new Error('expected an object of handlers with a GET entry')
+  }
+  const { GET } = handlers
+  if (typeof GET !== 'function') {
+    throw new Error('expected GET to be a bare handler function')
+  }
+  // The declared handler type is a union covering the framework's middleware form and
+  // a context argument this handler ignores. The guards above have already pinned it
+  // to the bare function; the assertion only drops parameters we never pass.
+  return GET as () => Promise<Response>
+}
+
+function arriveAtCallback(search: string): void {
+  mocks.getRequest.mockReturnValue(new Request(`http://localhost:3000/auth/callback${search}`))
+}
+
+let originalEnv: NodeJS.ProcessEnv
+
+beforeEach(() => {
+  originalEnv = { ...process.env }
+  Object.assign(process.env, VALID_ENV)
+  mocks.getCookie.mockReturnValue(STATE)
+})
+
+afterEach(() => {
+  process.env = originalEnv
+  vi.clearAllMocks()
+})
+
+describe('GET /auth/callback', () => {
+  it('seals the session and sends the user home on a good code', async () => {
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    mocks.authenticateWithCode.mockResolvedValue({ sealedSession: 'sealed-cookie' })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/')
+    expect(mocks.setCookie).toHaveBeenCalledWith('fns_session', 'sealed-cookie', expect.anything())
+  })
+
+  it('restarts the login when WorkOS rejects the code', async () => {
+    // Regression: authorization codes are single-use and short-lived, so this is an
+    // ordinary outcome (refresh, back button, a slow user). It used to be a 500.
+    arriveAtCallback(`?code=expired_code&state=${STATE}`)
+    mocks.authenticateWithCode.mockRejectedValue(
+      new OauthException(400, 'req_1', 'invalid_grant', 'The code has expired.', {}),
+    )
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/auth/login')
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow an unexpected failure as a redirect', async () => {
+    // A network blip or a bad API key is our bug, not the visitor's. Surfacing it
+    // beats bouncing them between login and callback forever.
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    mocks.authenticateWithCode.mockRejectedValue(new Error('socket hang up'))
+
+    await expect(getHandler()()).rejects.toThrow('socket hang up')
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+  })
+
+  it('rejects a callback with no authorization code', async () => {
+    arriveAtCallback(`?state=${STATE}`)
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain('Missing authorization code')
+    expect(mocks.authenticateWithCode).not.toHaveBeenCalled()
+  })
+
+  it('rejects a forged state before ever contacting WorkOS', async () => {
+    arriveAtCallback('?code=attacker_code&state=forged')
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain('Invalid OAuth state')
+    expect(mocks.authenticateWithCode).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/auth.callback.ts
+++ b/src/routes/auth.callback.ts
@@ -1,0 +1,44 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getRequest } from '@tanstack/react-start/server'
+import { getWorkOSConfig } from '../lib/auth/config.server'
+import { isSameOAuthState } from '../lib/auth/oauth-state'
+import { getWorkOS, setSessionCookie, takeOAuthStateCookie } from '../lib/auth/session.server'
+import { redirectResponse } from '../lib/http'
+
+// Server-only: no `component`, so the client route tree never imports this file.
+export const Route = createFileRoute('/auth/callback')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const url = new URL(getRequest().url)
+        const code = url.searchParams.get('code')
+        const state = url.searchParams.get('state')
+
+        // Always consume the state cookie, even on the failure paths, so a
+        // botched attempt can't be replayed against a still-live state.
+        const expectedState = takeOAuthStateCookie()
+
+        if (!code) {
+          return new Response('Missing authorization code', { status: 400 })
+        }
+        if (!state || !expectedState || !isSameOAuthState(state, expectedState)) {
+          return new Response('Invalid OAuth state', { status: 400 })
+        }
+
+        const { clientId, cookiePassword } = getWorkOSConfig()
+        const { sealedSession } = await getWorkOS().userManagement.authenticateWithCode({
+          code,
+          clientId,
+          session: { sealSession: true, cookiePassword },
+        })
+
+        if (!sealedSession) {
+          throw new Error('WorkOS returned no sealed session for the authorization code')
+        }
+
+        setSessionCookie(sealedSession)
+        return redirectResponse('/')
+      },
+    },
+  },
+})

--- a/src/routes/auth.callback.ts
+++ b/src/routes/auth.callback.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getRequest } from '@tanstack/react-start/server'
+import { OauthException } from '@workos-inc/node'
 import { getWorkOSConfig } from '../lib/auth/config.server'
 import { isSameOAuthState } from '../lib/auth/oauth-state'
 import { getWorkOS, setSessionCookie, takeOAuthStateCookie } from '../lib/auth/session.server'
@@ -26,11 +27,24 @@ export const Route = createFileRoute('/auth/callback')({
         }
 
         const { clientId, cookiePassword } = getWorkOSConfig()
-        const { sealedSession } = await getWorkOS().userManagement.authenticateWithCode({
-          code,
-          clientId,
-          session: { sealSession: true, cookiePassword },
-        })
+
+        let sealedSession: string | undefined
+        try {
+          ;({ sealedSession } = await getWorkOS().userManagement.authenticateWithCode({
+            code,
+            clientId,
+            session: { sealSession: true, cookiePassword },
+          }))
+        } catch (error) {
+          // Authorization codes are single-use and short-lived, so WorkOS rejecting
+          // one is ordinary: the visitor sat on the page, refreshed the callback, or
+          // came back through history. Start the login over rather than show a 500.
+          if (error instanceof OauthException) {
+            return redirectResponse('/auth/login')
+          }
+          // Anything else — the network, a bad API key — is our problem, not theirs.
+          throw error
+        }
 
         if (!sealedSession) {
           throw new Error('WorkOS returned no sealed session for the authorization code')

--- a/src/routes/auth.login.ts
+++ b/src/routes/auth.login.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getWorkOSConfig } from '../lib/auth/config.server'
+import { createOAuthState } from '../lib/auth/oauth-state'
+import { getWorkOS, setOAuthStateCookie } from '../lib/auth/session.server'
+import { redirectResponse } from '../lib/http'
+
+// Server-only: no `component`, so the client route tree never imports this file.
+export const Route = createFileRoute('/auth/login')({
+  server: {
+    handlers: {
+      GET: () => {
+        const { clientId, redirectUri } = getWorkOSConfig()
+
+        const state = createOAuthState()
+        setOAuthStateCookie(state)
+
+        const authorizationUrl = getWorkOS().userManagement.getAuthorizationUrl({
+          provider: 'GoogleOAuth',
+          clientId,
+          redirectUri,
+          state,
+        })
+
+        return redirectResponse(authorizationUrl)
+      },
+    },
+  },
+})

--- a/src/routes/auth.logout.ts
+++ b/src/routes/auth.logout.ts
@@ -1,0 +1,36 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getCookie } from '@tanstack/react-start/server'
+import { getWorkOSConfig } from '../lib/auth/config.server'
+import { SESSION_COOKIE_NAME, clearSessionCookie, getWorkOS } from '../lib/auth/session.server'
+import { redirectResponse } from '../lib/http'
+
+// POST rather than GET: a GET logout is trivially CSRF-able, and link prefetchers
+// and mail scanners would sign people out just by following the URL.
+// Server-only: no `component`, so the client route tree never imports this file.
+export const Route = createFileRoute('/auth/logout')({
+  server: {
+    handlers: {
+      POST: async () => {
+        const sessionData = getCookie(SESSION_COOKIE_NAME)
+
+        // Drop our cookie first: whatever WorkOS says next, this browser is signed out.
+        clearSessionCookie()
+
+        if (!sessionData) {
+          return redirectResponse('/')
+        }
+
+        const { cookiePassword } = getWorkOSConfig()
+        const sealed = getWorkOS().userManagement.loadSealedSession({
+          sessionData,
+          cookiePassword,
+        })
+
+        // An expired or tampered cookie can't produce a logout URL. The local
+        // cookie is already gone, so finishing at '/' is the correct outcome.
+        const logoutUrl = await sealed.getLogoutUrl().catch(() => null)
+        return redirectResponse(logoutUrl ?? '/')
+      },
+    },
+  },
+})


### PR DESCRIPTION
Ships the **session half** of FNS-91: login → callback → logout, with a sealed
`httpOnly` session cookie held entirely by the BFF.

JIT-provisioning the canonical user via `IdentityService.ResolveUser` is **deliberately
deferred** — it needs `@fair-n-square-co/apis` on GitHub Packages, and that package has
never been published (`gen/ts/package.json` is `private: true`, no `version`, no
`publishConfig`; `release-pkg.yml` has no npm publish step). That's now the critical path
for the follow-up.

## What's here

| Route | Method | Does |
| --- | --- | --- |
| `/auth/login` | GET | Mints an OAuth `state` cookie, redirects to AuthKit (Google) |
| `/auth/callback` | GET | Verifies `state`, exchanges the code, seals the session cookie |
| `/auth/logout` | POST | Clears the cookie, redirects to the WorkOS logout URL |

Plus `getSession()` / `requireSession()` in `src/lib/auth/session.server.ts`, which unseal
the cookie and expose the WorkOS **access token** to server functions.

## Notes for review

- **No secrets in the client bundle.** The auth routes declare a `server` block and no
  `component`, so the Start plugin's `pruneServerOnlySubtrees` strips them from the client
  route tree. Verified against a real build: `dist/client` contains no `workos`, no key
  material, no handlers.
- **Login-CSRF.** `state` is 32 random bytes in an `httpOnly` cookie, compared in constant
  time. Without it, an attacker can hand a victim a callback URL bearing the attacker's
  `code` and log the victim into the attacker's account.
- **Logout is POST.** A GET logout is CSRF-able, and link prefetchers and mail scanners
  sign people out just by following the URL.
- **Token refresh.** Access tokens expire in ~5 minutes. `getSession()` retries once
  through the refresh token and re-seals the cookie, so the session survives.
- **`only-throw-error`.** `throw redirect(...)` is TanStack's control flow. The rule is
  configured to allow exactly `Redirect` from `@tanstack/router-core` rather than being
  suppressed per call site.
- `createServerFileRoute` **does not exist** in Start 1.168 despite what current docs show;
  the typed form is `createFileRoute(...)({ server: { handlers } })`.

## Testing

`typecheck`, `lint`, `format:check`, 19 Vitest tests, 8 Playwright tests — all green.

The e2e specs use Playwright's `request` fixture (runs no JavaScript), asserting the 302 to
`api.workos.com`, the `HttpOnly` state cookie, and all three callback rejection paths.

**Not covered:** the happy path never crosses the WorkOS boundary — real `code` exchange,
seal, and unseal are untested, since they need live credentials. `getSession()` and
`requireSession()` are exercised only by `tsc`. Covering this properly wants an MSW-backed
Vitest integration test at the network boundary, which needs some server-runtime
(`AsyncLocalStorage`) scaffolding. Happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dso9oXCDfBSN81Bfx9XXRn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WorkOS-backed Google sign-in with server-only `/auth/login`, `/auth/callback`, and `/auth/logout` flows.
  - Implemented BFF session handling with sealed session cookies and OAuth state validation, including automatic session refresh.
  - Added unauthenticated redirects to the login flow and logout support via POST with redirect to `/`.

- **Documentation**
  - Updated `.env.example` and README setup to require `WORKOS_*` values for auth routes.
  - Added expanded endpoint documentation and redirect/logout behavior notes.

- **Tests**
  - Added Playwright end-to-end coverage for redirects, cookies, and callback error handling.
  - Added unit tests for environment validation, OAuth state security, and session lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->