### PR TITLE
feat: JIT-provision the canonical user on first login (FNS-91b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,9 @@ WORKOS_COOKIE_PASSWORD=
 WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 
 # The Go auth service, reached over connectRPC. The BFF calls ResolveUser here on
-# login to provision the canonical user record.
+# login to provision the canonical user record. Must be http or https.
 AUTH_SERVICE_BASE_URL=http://localhost:8080
+
+# Optional. How long the BFF waits on that call before giving up, in milliseconds.
+# Defaults to 5000. A login blocks on it, so it is bounded rather than left to hang.
+# AUTH_SERVICE_TIMEOUT_MS=5000

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ WORKOS_COOKIE_PASSWORD=
 
 # Must be registered verbatim as a redirect URI in the WorkOS dashboard.
 WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+
+# The Go auth service, reached over connectRPC. The BFF calls ResolveUser here on
+# login to provision the canonical user record.
+AUTH_SERVICE_BASE_URL=http://localhost:8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+# `@fair-n-square-co/apis` comes from GitHub Packages, which is private, so every
+# `bun install` needs a token that can read it (see .npmrc). The built-in token is
+# enough, provided the `apis` package grants this repo read access.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -12,6 +19,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run format:check
@@ -33,5 +42,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bunx playwright install --with-deps chromium
       - run: bun run test:e2e

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@fair-n-square-co:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,14 @@ FROM oven/bun:1.3.13
 WORKDIR /app
 
 # Install deps first so the layer caches independently of source changes.
-COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+# `.npmrc` points the @fair-n-square-co scope at GitHub Packages and reads the token
+# from the environment, so it holds no secret and is safe to bake into the layer. The
+# token itself is mounted for the install only — an ARG or ENV would persist it in the
+# image history. Build with:
+#   docker build --secret id=github_token,env=GITHUB_TOKEN .
+COPY package.json bun.lock .npmrc ./
+RUN --mount=type=secret,id=github_token \
+  GITHUB_TOKEN="$(cat /run/secrets/github_token)" bun install --frozen-lockfile
 
 # App source.
 COPY . .

--- a/README.md
+++ b/README.md
@@ -10,15 +10,22 @@ TypeScript (strict) · React 19
 ## Develop
 
 ```sh
+export GITHUB_TOKEN=...   # a PAT with `read:packages` — see below
 bun install
-cp .env.example .env   # then fill in the WorkOS values
-bun run dev            # http://localhost:3000  (SSR + HMR)
+cp .env.example .env      # then fill in the WorkOS values
+bun run dev               # http://localhost:3000  (SSR + HMR)
 ```
+
+The generated API clients ship as `@fair-n-square-co/apis` on GitHub Packages, which is
+private, so `bun install` needs `GITHUB_TOKEN` set to a PAT with `read:packages` — without
+it the install 401s. [`.npmrc`](./.npmrc) points the scope at that registry and reads the
+token from the environment, so no credential is ever committed.
 
 Routes live in `src/routes/`, shared UI in `src/components/`.
 
-The auth routes need the `WORKOS_*` variables in [`.env.example`](./.env.example); the rest
-of the app runs without them, since the config is read per-request rather than at boot.
+The auth routes need the `WORKOS_*` and `AUTH_SERVICE_BASE_URL` variables in
+[`.env.example`](./.env.example); the rest of the app runs without them, since the config is
+read per-request rather than at boot.
 
 | Script | What |
 | --- | --- |
@@ -42,7 +49,8 @@ code style lives in [`docs/coding-standards/react-typescript.md`](./docs/coding-
 Auth (server-only handlers; no client bundle, no component):
 
 - `GET /auth/login` — issues an OAuth `state` cookie, redirects to WorkOS AuthKit (Google).
-- `GET /auth/callback` — verifies `state`, exchanges the code, seals the session cookie.
+- `GET /auth/callback` — verifies `state`, exchanges the code, provisions the canonical
+  user, then seals the session cookie.
 - `POST /auth/logout` — clears the session cookie, redirects to the WorkOS logout URL.
   POST, not GET: a GET logout is CSRF-able and gets triggered by link prefetchers.
 
@@ -50,12 +58,23 @@ The browser only ever holds an opaque, sealed, `httpOnly` cookie. It is unsealed
 on the server, which is where the WorkOS access token is read before being forwarded to
 the Go services.
 
+The callback is also where the BFF makes its first connectRPC call: `IdentityService.
+ResolveUser` on the auth service, which JIT-provisions the canonical user on first login
+and returns the existing one on every login after. The access token travels in
+`Authorization` metadata and only the email is in the body (ADR-4: the service trusts the
+token, not the request fields). The cookie is set **after** that call succeeds — a visitor
+with a WorkOS session but no canonical user is half-authenticated, so a provisioning
+failure yields a 503 and a retry, never a broken session.
+
 ## Docker
 
 ```sh
-docker build -t fns-webapp .
+docker build --secret id=github_token,env=GITHUB_TOKEN -t fns-webapp .
 docker run -p 3000:3000 fns-webapp
 ```
+
+The build needs `GITHUB_TOKEN` for the same reason `bun install` does. It is passed as a
+BuildKit secret rather than a build arg so it never lands in the image history.
 
 The image runs the **dev server** — "good enough for docker-compose" local bring-up
 (FNS-90). A production multi-stage build with proper SSR client-asset serving is

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,10 @@
     "": {
       "name": "@fair-n-square-co/webapp",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.12.1",
+        "@connectrpc/connect": "^2.1.2",
+        "@connectrpc/connect-web": "^2.1.2",
+        "@fair-n-square-co/apis": "^0.1.0",
         "@tanstack/react-router": "^1.170.17",
         "@tanstack/react-start": "^1.168.27",
         "@workos-inc/node": "^10.7.0",
@@ -81,6 +85,12 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.1", "", {}, "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg=="],
+
+    "@connectrpc/connect": ["@connectrpc/connect@2.1.2", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA=="],
+
+    "@connectrpc/connect-web": ["@connectrpc/connect-web@2.1.2", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect": "2.1.2" } }, "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
@@ -116,6 +126,8 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@fair-n-square-co/apis": ["@fair-n-square-co/apis@0.1.0", "https://npm.pkg.github.com/download/@fair-n-square-co/apis/0.1.0/e01f8cd88073171c6b96aa6c024b735905de119c", { "dependencies": { "@bufbuild/protobuf": "^2.9.0" } }, "sha512-8PeTP5IzfAJuPCqhOfPUGbdHCH0o71boOjs7nqIkDbWor9j3+OlMvFiVLyUaPr/C6gln9eTyzIWHxcfzPUdlWA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.12.1",
+    "@connectrpc/connect": "^2.1.2",
+    "@connectrpc/connect-web": "^2.1.2",
+    "@fair-n-square-co/apis": "^0.1.0",
     "@tanstack/react-router": "^1.170.17",
     "@tanstack/react-start": "^1.168.27",
     "@workos-inc/node": "^10.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
       WORKOS_CLIENT_ID: 'client_placeholder',
       WORKOS_COOKIE_PASSWORD: 'placeholder-cookie-password-32-chars',
       WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+      // Same story: the callback never reaches ResolveUser in these specs, so this
+      // only has to parse as a URL — nothing ever connects to it.
+      AUTH_SERVICE_BASE_URL: 'http://localhost:8080',
     },
   },
 })

--- a/src/lib/auth/config.server.test.ts
+++ b/src/lib/auth/config.server.test.ts
@@ -57,7 +57,7 @@ describe('getWorkOSConfig', () => {
 
 describe('getAuthServiceConfig', () => {
   it('reads the auth service base URL from the environment', () => {
-    expect(getAuthServiceConfig()).toEqual({ baseUrl: 'http://localhost:8080' })
+    expect(getAuthServiceConfig()).toEqual({ baseUrl: 'http://localhost:8080', timeoutMs: 5000 })
   })
 
   it('throws when AUTH_SERVICE_BASE_URL is missing', () => {
@@ -72,5 +72,25 @@ describe('getAuthServiceConfig', () => {
     // later as a puzzling 404 rather than here as a misconfiguration.
     process.env['AUTH_SERVICE_BASE_URL'] = '/auth'
     expect(() => getAuthServiceConfig()).toThrow(/must be an absolute URL/)
+  })
+
+  it.each(['file:///auth', 'mailto:auth@example.com'])(
+    'rejects the absolute-but-unusable base URL %s',
+    (baseUrl) => {
+      // `new URL` accepts these happily. Only a scheme check stops them passing validation
+      // and then failing every call at runtime instead.
+      process.env['AUTH_SERVICE_BASE_URL'] = baseUrl
+      expect(() => getAuthServiceConfig()).toThrow(/must be http or https/)
+    },
+  )
+
+  it('takes a timeout override from the environment', () => {
+    process.env['AUTH_SERVICE_TIMEOUT_MS'] = '250'
+    expect(getAuthServiceConfig().timeoutMs).toBe(250)
+  })
+
+  it.each(['0', '-1', 'soon', '1.5'])('rejects the nonsensical timeout %s', (timeout) => {
+    process.env['AUTH_SERVICE_TIMEOUT_MS'] = timeout
+    expect(() => getAuthServiceConfig()).toThrow(/must be a positive integer/)
   })
 })

--- a/src/lib/auth/config.server.test.ts
+++ b/src/lib/auth/config.server.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getWorkOSConfig } from './config.server'
+import { getAuthServiceConfig, getWorkOSConfig } from './config.server'
 
-const VALID_ENV = {
+const WORKOS_ENV = {
   WORKOS_API_KEY: 'sk_test_key',
   WORKOS_CLIENT_ID: 'client_123',
   WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
   WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+} as const
+
+const VALID_ENV = {
+  ...WORKOS_ENV,
+  AUTH_SERVICE_BASE_URL: 'http://localhost:8080',
 } as const
 
 let originalEnv: NodeJS.ProcessEnv
@@ -29,12 +34,12 @@ describe('getWorkOSConfig', () => {
     })
   })
 
-  it.each(Object.keys(VALID_ENV))('throws when %s is missing', (name) => {
+  it.each(Object.keys(WORKOS_ENV))('throws when %s is missing', (name) => {
     delete process.env[name]
     expect(() => getWorkOSConfig()).toThrow(`Missing required environment variable: ${name}`)
   })
 
-  it.each(Object.keys(VALID_ENV))('throws when %s is empty', (name) => {
+  it.each(Object.keys(WORKOS_ENV))('throws when %s is empty', (name) => {
     process.env[name] = ''
     expect(() => getWorkOSConfig()).toThrow(`Missing required environment variable: ${name}`)
   })
@@ -47,5 +52,25 @@ describe('getWorkOSConfig', () => {
   it('accepts a cookie password of exactly the minimum length', () => {
     process.env['WORKOS_COOKIE_PASSWORD'] = 'a'.repeat(32)
     expect(getWorkOSConfig().cookiePassword).toHaveLength(32)
+  })
+})
+
+describe('getAuthServiceConfig', () => {
+  it('reads the auth service base URL from the environment', () => {
+    expect(getAuthServiceConfig()).toEqual({ baseUrl: 'http://localhost:8080' })
+  })
+
+  it('throws when AUTH_SERVICE_BASE_URL is missing', () => {
+    delete process.env['AUTH_SERVICE_BASE_URL']
+    expect(() => getAuthServiceConfig()).toThrow(
+      'Missing required environment variable: AUTH_SERVICE_BASE_URL',
+    )
+  })
+
+  it('rejects a base URL that is not absolute', () => {
+    // connectRPC only appends the method path to this, so a relative value would fail
+    // later as a puzzling 404 rather than here as a misconfiguration.
+    process.env['AUTH_SERVICE_BASE_URL'] = '/auth'
+    expect(() => getAuthServiceConfig()).toThrow(/must be an absolute URL/)
   })
 })

--- a/src/lib/auth/config.server.ts
+++ b/src/lib/auth/config.server.ts
@@ -41,21 +41,57 @@ export function getWorkOSConfig(): WorkOSConfig {
   }
 }
 
-/** Where the BFF reaches the Go auth service over connectRPC. */
+/**
+ * A call to the auth service holds the login open, so it gets a deadline rather than
+ * the transport's default of none. Without one, an auth service that accepts the
+ * connection and then stalls would hang the OAuth callback — and the request's server
+ * resources — for as long as it felt like.
+ */
+const DEFAULT_AUTH_SERVICE_TIMEOUT_MS = 5_000
+
+/** Where the BFF reaches the Go auth service over connectRPC, and how long it will wait. */
 export type AuthServiceConfig = Readonly<{
   baseUrl: string
+  timeoutMs: number
 }>
 
 export function getAuthServiceConfig(): AuthServiceConfig {
+  return {
+    baseUrl: requireAuthServiceBaseUrl(),
+    timeoutMs: readAuthServiceTimeoutMs(),
+  }
+}
+
+function requireAuthServiceBaseUrl(): string {
   const baseUrl = requireEnv('AUTH_SERVICE_BASE_URL')
 
-  // connectRPC appends `/<package>.<Service>/<Method>` to this, so a typo'd base
-  // would otherwise surface as a confusing 404 from whatever host it resolved to.
+  // connectRPC appends `/<package>.<Service>/<Method>` to this, so a typo'd base would
+  // otherwise surface as a confusing 404 from whatever host it resolved to. The scheme is
+  // checked too: `new URL` happily accepts `file:` or `mailto:`, which would pass this
+  // check and then fail every single call at runtime instead.
+  let url: URL
   try {
-    new URL(baseUrl)
+    url = new URL(baseUrl)
   } catch {
     throw new Error(`AUTH_SERVICE_BASE_URL must be an absolute URL, got: ${baseUrl}`)
   }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`AUTH_SERVICE_BASE_URL must be http or https, got: ${url.protocol}`)
+  }
 
-  return { baseUrl }
+  return baseUrl
+}
+
+/** Optional: an ops knob for a slow environment, not something a deploy has to set. */
+function readAuthServiceTimeoutMs(): number {
+  const configured = process.env['AUTH_SERVICE_TIMEOUT_MS']
+  if (configured === undefined || configured === '') {
+    return DEFAULT_AUTH_SERVICE_TIMEOUT_MS
+  }
+
+  const timeoutMs = Number(configured)
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`AUTH_SERVICE_TIMEOUT_MS must be a positive integer, got: ${configured}`)
+  }
+  return timeoutMs
 }

--- a/src/lib/auth/config.server.ts
+++ b/src/lib/auth/config.server.ts
@@ -1,5 +1,5 @@
 /**
- * WorkOS configuration, read from the environment.
+ * Auth configuration, read from the environment.
  *
  * Read lazily rather than at module scope: a missing variable should fail the
  * request that needs it, not the build or a `vite dev` boot that never touches auth.
@@ -39,4 +39,23 @@ export function getWorkOSConfig(): WorkOSConfig {
     cookiePassword,
     redirectUri: requireEnv('WORKOS_REDIRECT_URI'),
   }
+}
+
+/** Where the BFF reaches the Go auth service over connectRPC. */
+export type AuthServiceConfig = Readonly<{
+  baseUrl: string
+}>
+
+export function getAuthServiceConfig(): AuthServiceConfig {
+  const baseUrl = requireEnv('AUTH_SERVICE_BASE_URL')
+
+  // connectRPC appends `/<package>.<Service>/<Method>` to this, so a typo'd base
+  // would otherwise surface as a confusing 404 from whatever host it resolved to.
+  try {
+    new URL(baseUrl)
+  } catch {
+    throw new Error(`AUTH_SERVICE_BASE_URL must be an absolute URL, got: ${baseUrl}`)
+  }
+
+  return { baseUrl }
 }

--- a/src/lib/rpc/identity.server.ts
+++ b/src/lib/rpc/identity.server.ts
@@ -1,0 +1,107 @@
+import { createClient } from '@connectrpc/connect'
+import type { Client, Interceptor } from '@connectrpc/connect'
+import { createConnectTransport } from '@connectrpc/connect-web'
+import {
+  IdentityService,
+  ResolveUserResponse_Resolution,
+} from '@fair-n-square-co/apis/fairnsquare/service/authx/v1alpha1/authx_api_pb'
+import { getAuthServiceConfig } from '../auth/config.server'
+
+/**
+ * The BFF's connectRPC client for the Go auth service (ADR-4).
+ *
+ * Server-only. The WorkOS access token never leaves this process: it is attached
+ * to each call as `Authorization: Bearer <token>` metadata, and the service derives
+ * the caller's issuer/subject from it rather than trusting anything in the body.
+ */
+
+/** How `ResolveUser` resolved the identity — both outcomes are a successful login. */
+export type UserResolution = 'created' | 'found'
+
+/** The canonical user record, as the rest of the BFF cares about it. */
+export type ResolvedUser = Readonly<{
+  id: string
+  email: string
+  resolution: UserResolution
+}>
+
+function bearerToken(accessToken: string): Interceptor {
+  return (next) => (req) => {
+    req.header.set('Authorization', `Bearer ${accessToken}`)
+    return next(req)
+  }
+}
+
+/**
+ * A client is built per call rather than cached: the bearer token is baked into the
+ * interceptor, so a shared client would forward one user's token on another's call.
+ * The transport is a thin wrapper over `fetch`, so building one is cheap.
+ *
+ * `connect-web`, not `connect-node`, despite this running on the server: it is the
+ * fetch-based transport, and this server is already fetch-native (the Start runtime
+ * hands us `Request`/`Response`). connect-node instead reaches for `node:http`
+ * directly, which buys us HTTP/2 we don't need for unary calls and costs us a
+ * transport no `fetch` interceptor — MSW in tests, tracing later — can see.
+ */
+function createIdentityClient(accessToken: string): Client<typeof IdentityService> {
+  const { baseUrl } = getAuthServiceConfig()
+
+  const transport = createConnectTransport({
+    baseUrl,
+    // This transport defaults to JSON, which exists to keep payloads debuggable in a
+    // browser's network tab. Nothing here is server→server debuggable that way, so take
+    // the binary wire format the Go service already speaks.
+    useBinaryFormat: true,
+    interceptors: [bearerToken(accessToken)],
+  })
+
+  return createClient(IdentityService, transport)
+}
+
+/**
+ * Resolve the canonical user for a freshly authenticated WorkOS identity,
+ * JIT-provisioning them on first login.
+ *
+ * Idempotent: the first login reports `created`, every later one `found`. Both mean
+ * the user has a canonical record, which is the only thing the caller needs to know.
+ * Throws if the service is unreachable, rejects the token, or answers with a record
+ * the BFF cannot trust — never returns a half-resolved user.
+ */
+export async function resolveUser({
+  accessToken,
+  email,
+}: {
+  accessToken: string
+  email: string
+}): Promise<ResolvedUser> {
+  const response = await createIdentityClient(accessToken).resolveUser({ email })
+
+  // Everything below crosses the BFF boundary, and protobuf's wire format makes no
+  // promises about it: `user` is an optional message and `resolution` is an open enum,
+  // so a partial answer decodes cleanly into a useless value. Reject it here rather
+  // than let an empty user id travel on into the app.
+  const resolution = toUserResolution(response.resolution)
+  if (!resolution) {
+    throw new Error(
+      `auth service returned an unusable resolution for ResolveUser: ${response.resolution}`,
+    )
+  }
+  if (!response.user?.id) {
+    throw new Error('auth service returned no canonical user for ResolveUser')
+  }
+
+  return { id: response.user.id, email: response.user.email, resolution }
+}
+
+function toUserResolution(resolution: ResolveUserResponse_Resolution): UserResolution | null {
+  switch (resolution) {
+    case ResolveUserResponse_Resolution.CREATED:
+      return 'created'
+    case ResolveUserResponse_Resolution.FOUND:
+      return 'found'
+    case ResolveUserResponse_Resolution.UNSPECIFIED:
+      return null
+    default:
+      return null
+  }
+}

--- a/src/lib/rpc/identity.server.ts
+++ b/src/lib/rpc/identity.server.ts
@@ -44,7 +44,7 @@ function bearerToken(accessToken: string): Interceptor {
  * transport no `fetch` interceptor — MSW in tests, tracing later — can see.
  */
 function createIdentityClient(accessToken: string): Client<typeof IdentityService> {
-  const { baseUrl } = getAuthServiceConfig()
+  const { baseUrl, timeoutMs } = getAuthServiceConfig()
 
   const transport = createConnectTransport({
     baseUrl,
@@ -52,6 +52,8 @@ function createIdentityClient(accessToken: string): Client<typeof IdentityServic
     // browser's network tab. Nothing here is server→server debuggable that way, so take
     // the binary wire format the Go service already speaks.
     useBinaryFormat: true,
+    // A call with no deadline can hang the login for as long as the auth service stalls.
+    defaultTimeoutMs: timeoutMs,
     interceptors: [bearerToken(accessToken)],
   })
 
@@ -86,7 +88,7 @@ export async function resolveUser({
       `auth service returned an unusable resolution for ResolveUser: ${response.resolution}`,
     )
   }
-  if (!response.user?.id) {
+  if (!response.user?.id || !response.user.email) {
     throw new Error('auth service returned no canonical user for ResolveUser')
   }
 

--- a/src/routes/auth.callback.test.ts
+++ b/src/routes/auth.callback.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { OauthException } from '@workos-inc/node'
 import type * as WorkOSModule from '@workos-inc/node'
+import { ResolveUserResponse_Resolution } from '@fair-n-square-co/apis/fairnsquare/service/authx/v1alpha1/authx_api_pb'
+import { server } from '../test/msw/server'
+import {
+  TEST_AUTH_SERVICE_BASE_URL,
+  resolveUserHandler,
+  type RecordedResolveUser,
+  type ResolveUserOutcome,
+} from '../test/msw/identity'
 
 // External boundaries only: the Start server runtime (request-scoped cookie and
 // request helpers, which have no Vitest equivalent) and the WorkOS service.
@@ -37,9 +45,12 @@ const VALID_ENV = {
   WORKOS_CLIENT_ID: 'client_123',
   WORKOS_COOKIE_PASSWORD: 'a'.repeat(32),
   WORKOS_REDIRECT_URI: 'http://localhost:3000/auth/callback',
+  AUTH_SERVICE_BASE_URL: TEST_AUTH_SERVICE_BASE_URL,
 } as const
 
 const STATE = 'the-issued-state'
+const ACCESS_TOKEN = 'workos-access-token'
+const EMAIL = 'ada@example.com'
 
 /** Pull the bare GET handler off the route definition. */
 function getHandler(): () => Promise<Response> {
@@ -61,12 +72,28 @@ function arriveAtCallback(search: string): void {
   mocks.getRequest.mockReturnValue(new Request(`http://localhost:3000/auth/callback${search}`))
 }
 
+/** A successful code exchange: WorkOS returns the sealed session, the token and the user. */
+function workOSAcceptsTheCode(): void {
+  mocks.authenticateWithCode.mockResolvedValue({
+    sealedSession: 'sealed-cookie',
+    accessToken: ACCESS_TOKEN,
+    user: { email: EMAIL },
+  })
+}
+
 let originalEnv: NodeJS.ProcessEnv
+let resolveUserCalls: RecordedResolveUser[]
+
+/** Point the auth service at an outcome; every call it receives lands in `resolveUserCalls`. */
+function authServiceAnswers(outcome: ResolveUserOutcome): void {
+  server.use(resolveUserHandler(outcome, resolveUserCalls))
+}
 
 beforeEach(() => {
   originalEnv = { ...process.env }
   Object.assign(process.env, VALID_ENV)
   mocks.getCookie.mockReturnValue(STATE)
+  resolveUserCalls = []
 })
 
 afterEach(() => {
@@ -77,13 +104,71 @@ afterEach(() => {
 describe('GET /auth/callback', () => {
   it('seals the session and sends the user home on a good code', async () => {
     arriveAtCallback(`?code=good_code&state=${STATE}`)
-    mocks.authenticateWithCode.mockResolvedValue({ sealedSession: 'sealed-cookie' })
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'resolved', resolution: ResolveUserResponse_Resolution.CREATED })
 
     const res = await getHandler()()
 
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('/')
     expect(mocks.setCookie).toHaveBeenCalledWith('fns_session', 'sealed-cookie', expect.anything())
+  })
+
+  it('provisions the canonical user once, with the token in metadata and the email in the body', async () => {
+    // ADR-4 zero trust: the auth service derives issuer/subject from the token it can
+    // verify, so the email is the only thing it will take our word for.
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'resolved', resolution: ResolveUserResponse_Resolution.CREATED })
+
+    await getHandler()()
+
+    expect(resolveUserCalls).toEqual([{ email: EMAIL, authorization: `Bearer ${ACCESS_TOKEN}` }])
+  })
+
+  it('signs in an already-provisioned user without creating a second record', async () => {
+    // Every login after the first: same identity, same canonical user, no duplicate.
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'resolved', resolution: ResolveUserResponse_Resolution.FOUND })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/')
+    expect(mocks.setCookie).toHaveBeenCalledWith('fns_session', 'sealed-cookie', expect.anything())
+    expect(resolveUserCalls).toHaveLength(1)
+  })
+
+  it('does not establish a session when provisioning fails', async () => {
+    // A WorkOS cookie with no canonical user behind it is half-authenticated: every
+    // downstream call would fail. Better to hand back a retry than a broken session.
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'unavailable' })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(503)
+    expect(await res.text()).toContain('try signing in again')
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+    expect(logged).toHaveBeenCalled()
+  })
+
+  it('does not establish a session when the auth service answers without a user', async () => {
+    // `user` is an optional message and `resolution` an open enum, so an empty answer
+    // decodes perfectly well into one that means nothing. It must not sign anyone in.
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'incomplete' })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(503)
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+    expect(logged).toHaveBeenCalled()
   })
 
   it('restarts the login when WorkOS rejects the code', async () => {

--- a/src/routes/auth.callback.test.ts
+++ b/src/routes/auth.callback.test.ts
@@ -4,6 +4,7 @@ import type * as WorkOSModule from '@workos-inc/node'
 import { ResolveUserResponse_Resolution } from '@fair-n-square-co/apis/fairnsquare/service/authx/v1alpha1/authx_api_pb'
 import { server } from '../test/msw/server'
 import {
+  STALL_MS,
   TEST_AUTH_SERVICE_BASE_URL,
   resolveUserHandler,
   type RecordedResolveUser,
@@ -99,6 +100,10 @@ beforeEach(() => {
 afterEach(() => {
   process.env = originalEnv
   vi.clearAllMocks()
+  // Not just `clearAllMocks`: the failure tests silence `console.error` with a spy, and
+  // clearing a spy leaves that silent implementation in place. A later test's unexpected
+  // error would then vanish instead of being printed.
+  vi.restoreAllMocks()
 })
 
 describe('GET /auth/callback', () => {
@@ -154,6 +159,48 @@ describe('GET /auth/callback', () => {
     expect(await res.text()).toContain('try signing in again')
     expect(mocks.setCookie).not.toHaveBeenCalled()
     expect(logged).toHaveBeenCalled()
+  })
+
+  it('sends the failed visitor back to a fresh login, not back to the callback', async () => {
+    // The state cookie is spent and the authorization code is single-use, so retrying this
+    // request can only fail again. `Retry-After` would be advertising exactly that.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'unavailable' })
+
+    const res = await getHandler()()
+
+    expect(res.headers.get('retry-after')).toBeNull()
+    expect(await res.text()).toContain('href="/auth/login"')
+  })
+
+  it('gives up on an auth service that stalls rather than hanging the login', async () => {
+    // Without a deadline the callback would wait on a stalled service indefinitely, holding
+    // the request open with it.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.env['AUTH_SERVICE_TIMEOUT_MS'] = String(Math.floor(STALL_MS / 4))
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'stalls' })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(503)
+    expect(mocks.setCookie).not.toHaveBeenCalled()
+  })
+
+  it('does not establish a session when the canonical user has no email', async () => {
+    // `email` is as load-bearing as `id` and just as optional on the wire.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    arriveAtCallback(`?code=good_code&state=${STATE}`)
+    workOSAcceptsTheCode()
+    authServiceAnswers({ kind: 'userWithoutEmail' })
+
+    const res = await getHandler()()
+
+    expect(res.status).toBe(503)
+    expect(mocks.setCookie).not.toHaveBeenCalled()
   })
 
   it('does not establish a session when the auth service answers without a user', async () => {

--- a/src/routes/auth.callback.ts
+++ b/src/routes/auth.callback.ts
@@ -67,9 +67,15 @@ export const Route = createFileRoute('/auth/callback')({
           // downstream call would fail in ways much harder to read than this. Send them
           // back to a retry rather than into an app that cannot serve them.
           console.error('ResolveUser failed; refusing to establish the session', error)
+          // No `Retry-After`: that invites a retry of *this* request, which cannot work.
+          // The state cookie is spent and the authorization code is single-use, so the
+          // only way forward is a fresh login — link them to one rather than imply the
+          // callback is worth hitting again.
           return new Response(
-            "We couldn't finish setting up your account. Please try signing in again.",
-            { status: 503, headers: { 'retry-after': '5' } },
+            `<!doctype html><meta charset="utf-8"><title>Sign-in failed</title>` +
+              `<p>We couldn't finish setting up your account. ` +
+              `<a href="/auth/login">Please try signing in again.</a></p>`,
+            { status: 503, headers: { 'content-type': 'text/html; charset=utf-8' } },
           )
         }
 

--- a/src/routes/auth.callback.ts
+++ b/src/routes/auth.callback.ts
@@ -1,9 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getRequest } from '@tanstack/react-start/server'
 import { OauthException } from '@workos-inc/node'
+import type { User } from '@workos-inc/node'
 import { getWorkOSConfig } from '../lib/auth/config.server'
 import { isSameOAuthState } from '../lib/auth/oauth-state'
 import { getWorkOS, setSessionCookie, takeOAuthStateCookie } from '../lib/auth/session.server'
+import { resolveUser } from '../lib/rpc/identity.server'
 import { redirectResponse } from '../lib/http'
 
 // Server-only: no `component`, so the client route tree never imports this file.
@@ -29,12 +31,15 @@ export const Route = createFileRoute('/auth/callback')({
         const { clientId, cookiePassword } = getWorkOSConfig()
 
         let sealedSession: string | undefined
+        let accessToken: string
+        let user: User
         try {
-          ;({ sealedSession } = await getWorkOS().userManagement.authenticateWithCode({
-            code,
-            clientId,
-            session: { sealSession: true, cookiePassword },
-          }))
+          ;({ sealedSession, accessToken, user } =
+            await getWorkOS().userManagement.authenticateWithCode({
+              code,
+              clientId,
+              session: { sealSession: true, cookiePassword },
+            }))
         } catch (error) {
           // Authorization codes are single-use and short-lived, so WorkOS rejecting
           // one is ordinary: the visitor sat on the page, refreshed the callback, or
@@ -48,6 +53,24 @@ export const Route = createFileRoute('/auth/callback')({
 
         if (!sealedSession) {
           throw new Error('WorkOS returned no sealed session for the authorization code')
+        }
+
+        // First login is where the canonical user record gets provisioned (ADR-4), so
+        // this is the one request that must wait on the auth service — every later
+        // request just carries the token. `created` (first login) and `found` (every
+        // one after) are equally good outcomes; the call is idempotent.
+        try {
+          await resolveUser({ accessToken, email: user.email })
+        } catch (error) {
+          // The session is sealed but deliberately not set: a visitor holding a WorkOS
+          // cookie with no canonical user behind it is half-authenticated, and every
+          // downstream call would fail in ways much harder to read than this. Send them
+          // back to a retry rather than into an app that cannot serve them.
+          console.error('ResolveUser failed; refusing to establish the session', error)
+          return new Response(
+            "We couldn't finish setting up your account. Please try signing in again.",
+            { status: 503, headers: { 'retry-after': '5' } },
+          )
         }
 
         setSessionCookie(sealedSession)

--- a/src/test/msw/identity.ts
+++ b/src/test/msw/identity.ts
@@ -1,0 +1,79 @@
+import { HttpResponse, http } from 'msw'
+import type { RequestHandler } from 'msw'
+import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
+import {
+  ResolveUserRequestSchema,
+  ResolveUserResponseSchema,
+  ResolveUserResponse_Resolution,
+} from '@fair-n-square-co/apis/fairnsquare/service/authx/v1alpha1/authx_api_pb'
+
+/**
+ * MSW handlers for the auth service's `IdentityService`, mocked at the wire (§9)
+ * rather than by stubbing our own connectRPC client.
+ *
+ * That means these speak real Connect: the BFF's client serializes a request the
+ * handler has to decode with the generated schema, and only accepts a reply it can
+ * decode back. A test therefore fails if we get the protocol, the route, or the
+ * message shape wrong — which is precisely the contract worth guarding.
+ */
+
+/** Matches `AUTH_SERVICE_BASE_URL` in the tests that install these handlers. */
+export const TEST_AUTH_SERVICE_BASE_URL = 'http://auth.test'
+
+// Connect addresses a unary method as POST <baseUrl>/<package>.<Service>/<Method>.
+const RESOLVE_USER_URL = `${TEST_AUTH_SERVICE_BASE_URL}/fairnsquare.service.authx.v1alpha1.IdentityService/ResolveUser`
+
+/** What the BFF actually put on the wire, so a test can assert on it. */
+export type RecordedResolveUser = Readonly<{
+  email: string
+  authorization: string | null
+}>
+
+export type ResolveUserOutcome =
+  | Readonly<{ kind: 'resolved'; resolution: ResolveUserResponse_Resolution }>
+  /** A well-formed reply the BFF must still refuse: no user, or an unusable resolution. */
+  | Readonly<{ kind: 'incomplete' }>
+  | Readonly<{ kind: 'unavailable' }>
+
+/**
+ * Handle `ResolveUser` with the given outcome, appending each call to `calls`.
+ * Both `CREATED` and `FOUND` are ordinary successes — the difference is only whether
+ * this was the user's first login.
+ */
+export function resolveUserHandler(
+  outcome: ResolveUserOutcome,
+  calls: RecordedResolveUser[],
+): RequestHandler {
+  return http.post(RESOLVE_USER_URL, async ({ request }) => {
+    const message = fromBinary(
+      ResolveUserRequestSchema,
+      new Uint8Array(await request.arrayBuffer()),
+    )
+    calls.push({
+      email: message.email,
+      authorization: request.headers.get('authorization'),
+    })
+
+    if (outcome.kind === 'unavailable') {
+      // Connect reports errors as JSON with an HTTP status, whatever the body format.
+      return HttpResponse.json(
+        { code: 'unavailable', message: 'auth service is down' },
+        { status: 503 },
+      )
+    }
+
+    const response =
+      outcome.kind === 'incomplete'
+        ? create(ResolveUserResponseSchema, {
+            resolution: ResolveUserResponse_Resolution.UNSPECIFIED,
+          })
+        : create(ResolveUserResponseSchema, {
+            resolution: outcome.resolution,
+            user: { id: 'user_01HZY', email: message.email },
+          })
+
+    return HttpResponse.arrayBuffer(toBinary(ResolveUserResponseSchema, response).buffer, {
+      headers: { 'content-type': 'application/proto' },
+    })
+  })
+}

--- a/src/test/msw/identity.ts
+++ b/src/test/msw/identity.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, http } from 'msw'
+import { HttpResponse, delay, http } from 'msw'
 import type { RequestHandler } from 'msw'
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
 import {
@@ -29,11 +29,17 @@ export type RecordedResolveUser = Readonly<{
   authorization: string | null
 }>
 
+/** How long a `stalls` outcome hangs for — comfortably past any timeout a test sets. */
+export const STALL_MS = 400
+
 export type ResolveUserOutcome =
   | Readonly<{ kind: 'resolved'; resolution: ResolveUserResponse_Resolution }>
-  /** A well-formed reply the BFF must still refuse: no user, or an unusable resolution. */
+  /** Well-formed replies the BFF must still refuse: no usable resolution, or no email. */
   | Readonly<{ kind: 'incomplete' }>
+  | Readonly<{ kind: 'userWithoutEmail' }>
   | Readonly<{ kind: 'unavailable' }>
+  /** Accepts the request, then never answers — the case a deadline exists for. */
+  | Readonly<{ kind: 'stalls' }>
 
 /**
  * Handle `ResolveUser` with the given outcome, appending each call to `calls`.
@@ -54,6 +60,10 @@ export function resolveUserHandler(
       authorization: request.headers.get('authorization'),
     })
 
+    if (outcome.kind === 'stalls') {
+      await delay(STALL_MS)
+    }
+
     if (outcome.kind === 'unavailable') {
       // Connect reports errors as JSON with an HTTP status, whatever the body format.
       return HttpResponse.json(
@@ -67,10 +77,18 @@ export function resolveUserHandler(
         ? create(ResolveUserResponseSchema, {
             resolution: ResolveUserResponse_Resolution.UNSPECIFIED,
           })
-        : create(ResolveUserResponseSchema, {
-            resolution: outcome.resolution,
-            user: { id: 'user_01HZY', email: message.email },
-          })
+        : outcome.kind === 'userWithoutEmail'
+          ? create(ResolveUserResponseSchema, {
+              resolution: ResolveUserResponse_Resolution.CREATED,
+              user: { id: 'user_01HZY' },
+            })
+          : create(ResolveUserResponseSchema, {
+              resolution:
+                outcome.kind === 'stalls'
+                  ? ResolveUserResponse_Resolution.FOUND
+                  : outcome.resolution,
+              user: { id: 'user_01HZY', email: message.email },
+            })
 
     return HttpResponse.arrayBuffer(toBinary(ResolveUserResponseSchema, response).buffer, {
       headers: { 'content-type': 'application/proto' },


### PR DESCRIPTION
Second half of FNS-91. FNS-91a (login/callback/logout/sealed session) landed in #2; this wires the BFF's **first connectRPC call** to the Go `auth` service.

## What it does

On the OAuth callback, once WorkOS has sealed the session, the BFF calls `IdentityService.ResolveUser`. The access token goes in `Authorization` metadata and only the email in the body, so the service derives issuer/subject from a token it can verify rather than from asserted request fields (ADR-4 zero trust). `CREATED` (first login) and `FOUND` (every login after) are both successes — the call is idempotent, so a repeat login provisions no duplicate.

**The session cookie is set only after that call succeeds.** A visitor holding a WorkOS session with no canonical user behind it is half-authenticated, and every downstream call would fail obscurely. A provisioning failure yields a 503 with a retry rather than a broken session. Two tests pin this ordering — both go red if the cookie is set before provisioning.

Because `user` is an optional message and `resolution` an open enum, a hollow reply decodes perfectly well into one that means nothing, so the response is validated at the BFF boundary before anyone is signed in.

## Why the fetch transport, not `connect-node`

`@connectrpc/connect-web` despite this running on the server. The Start runtime is already fetch-native, unary calls need nothing HTTP/2 buys, and `connect-node` reaches for `node:http` directly — a transport no `fetch` interceptor can see.

That last point isn't academic. MSW intercepts by patching `node:http`'s CJS exports, but `connect-node`'s ESM namespace import snapshots them first (verified: `ESM ns request === CJS request? false`), so its requests **escape the mock and hit the real network**. Tests would have been mocking nothing. The fetch transport keeps them honest at the network boundary.

## Tests

MSW handlers speak real Connect over the wire (`src/test/msw/identity.ts`) — the client serializes a request the handler decodes with the generated schema, and only accepts a reply it can decode back. So the protocol, route and message shape are all under test, not stubbed. Each new test was confirmed red before green.

- ResolveUser is called once, with `Bearer <token>` in metadata and the email in the body
- `CREATED` and `FOUND` both sign the user in; `FOUND` creates no second record
- A ResolveUser failure — unavailable, or a reply with no user — never seals a usable session

## Packaging

`@fair-n-square-co/apis` lives on GitHub Packages (private), so `bun install` now needs `GITHUB_TOKEN`. `.npmrc` reads it from the environment and holds no secret. CI passes the built-in token; the Docker build takes it as a BuildKit secret so it never lands in the image history.

> ⚠️ **CI will 401 unless the `apis` package grants this repo read access** (Package settings → Manage Actions access → add `webapp`). Worth checking on the first run.

## Gates

`typecheck` · `lint` · `format:check` · `test` (39) · `playwright` (8) · `bun run build` · `docker build` — all green locally. No server-only code in the client bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zSjCivCzWL94JoErEY96H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auth-service integration to resolve and provision users during sign-in.
  * Sessions are created only after successful user resolution.
  * Added configuration for the external auth service URL.

* **Bug Fixes**
  * Authentication failures now return a retryable 503 response without creating a session.

* **Documentation**
  * Updated setup, authentication, and Docker deployment instructions.

* **Chores**
  * Improved package authentication for local, CI, and container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->